### PR TITLE
Replace legacy cv::Mat constructor with cv::cvarrToMat helper function

### DIFF
--- a/src/modules/visionDepth/SegmentorThread.cpp
+++ b/src/modules/visionDepth/SegmentorThread.cpp
@@ -192,7 +192,7 @@ void SegmentorThread::run() {
     IplImage *inIplImage = cvCreateImage(cvSize(inYarpImg.width(), inYarpImg.height()),
                                          IPL_DEPTH_8U, 3 );
     cvCvtColor((IplImage*)inYarpImg.getIplImage(), inIplImage, CV_RGB2BGR);
-    Mat inCvMat(inIplImage);
+    Mat inCvMat = cvarrToMat(inIplImage);
 
     PixelRgb green(0,255,0);
     // publish the original yarp img if crop selector invoked.

--- a/src/modules/visionDepth/SegmentorThread.hpp
+++ b/src/modules/visionDepth/SegmentorThread.hpp
@@ -57,6 +57,8 @@ using namespace yarp::dev;
 using namespace yarp::sig;
 using namespace yarp::sig::draw;
 
+using namespace cv;
+
 class DataProcessor : public PortReader {
     virtual bool read(ConnectionReader& connection) {
         Bottle b;

--- a/src/modules/visionSegmentor/SegmentorThread.cpp
+++ b/src/modules/visionSegmentor/SegmentorThread.cpp
@@ -91,7 +91,7 @@ void SegmentorThread::run() {
     IplImage *inIplImage = cvCreateImage(cvSize(inYarpImg->width(), inYarpImg->height()),
                                          IPL_DEPTH_8U, 3 );
     cvCvtColor((IplImage*)inYarpImg->getIplImage(), inIplImage, CV_RGB2BGR);
-    Mat inCvMat(inIplImage);
+    Mat inCvMat = cvarrToMat(inIplImage);
 
     // Because Travis stuff goes with [openCv Mat Bgr] for now
     Travis travis(false,true);    // ::Travis(quiet=true, overwrite=true);


### PR DESCRIPTION
Mat::Mat(const IplImage\* img, bool copyData=false) constructor has been
removed in OpenCV 3.x. Also add missing 'using' directive.

References:
- http://docs.opencv.org/2.4/modules/core/doc/basic_structures.html#mat-mat
- http://docs.opencv.org/3.1.0/d3/d63/classcv_1_1Mat.html#pub-methods
- http://answers.opencv.org/question/23440
- http://docs.opencv.org/2.4/modules/core/doc/operations_on_arrays.html#cvarrtomat
