### PR TITLE
Implement yarp::dev::IControlMode in RaveBot plugin

### DIFF
--- a/src/libraries/RlPlugins/ravebot/CMakeLists.txt
+++ b/src/libraries/RlPlugins/ravebot/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 link_directories(${OpenRAVE_LIBRARY_DIRS} ${OPENRAVE_LINK_DIRS}) # All caps -> older
 
-YARP_ADD_PLUGIN(ravebot RaveBot.h IDeviceImpl.cpp IPositionImpl.cpp IVelocityImpl.cpp IEncoderImpl.cpp RateThreadImpl.cpp IControlLimitsImpl.cpp SharedArea.cpp WorldRpcResponder.cpp MobileRpcResponder.cpp ExtraCallbackPort.cpp)
+YARP_ADD_PLUGIN(ravebot RaveBot.h IDeviceImpl.cpp IPositionImpl.cpp IVelocityImpl.cpp IEncoderImpl.cpp RateThreadImpl.cpp IControlLimitsImpl.cpp IControlModeImpl.cpp SharedArea.cpp WorldRpcResponder.cpp MobileRpcResponder.cpp ExtraCallbackPort.cpp)
 set_target_properties(ravebot PROPERTIES COMPILE_FLAGS "${OpenRAVE_CXX_FLAGS}")
 set_target_properties(ravebot PROPERTIES LINK_FLAGS "${OpenRAVE_LINK_FLAGS}")
 TARGET_LINK_LIBRARIES(ravebot ${YARP_LIBRARIES} ${OpenRAVE_CORE_LIBRARIES} ${OPENRAVE_CORE_LIBRARY} ${Boost_THREAD_LIBRARY} ${BOOSt_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${BOOST_SYSTEM_LIBRARY})

--- a/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
@@ -55,13 +55,18 @@ bool RaveBot::setOpenLoopMode(int j) {
 // -----------------------------------------------------------------------------
 
 bool RaveBot::getControlMode(int j, int *mode) {
-    return false; // unimplemented
+    if ((unsigned int)j>numMotors) return false;
+    *mode = vModePosVel[j];
+    return true;
 }
 
 // -----------------------------------------------------------------------------
 
 bool RaveBot::getControlModes(int *modes) {
-    return false; // unimplemented
+    for(unsigned int motor=0;motor<numMotors;motor++) {
+        modes[motor] = vModePosVel[motor];
+    }
+    return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
@@ -7,13 +7,13 @@
 bool RaveBot::setPositionMode(int j) {
     printf("[RaveBot] setPositionMode(%d)\n", j);
     if ((unsigned int)j>numMotors) return false;
-    if (vModePosVel[j]==0) return true;  // Simply return true if we were already in pos mode.
+    if (vModePosVel[j]==VOCAB_POSITION_MODE) return true;  // Simply return true if we were already in pos mode.
     // Do anything additional before setting flag to pos...
     if(!stop()) {
         fprintf(stderr,"[RaveBot] warning: setPositionMode() return false; failed to stop\n");
         return false;
     }
-    vModePosVel[j] = 0;  // Set flag to pos.
+    vModePosVel[j] = VOCAB_POSITION_MODE;  // Set flag to pos.
     return true;
 }
 
@@ -22,9 +22,9 @@ bool RaveBot::setPositionMode(int j) {
 bool RaveBot::setVelocityMode(int j) {
     printf("[RaveBot] setVelocityMode(%d)\n", j);
     if ((unsigned int)j>numMotors) return false;
-    if (vModePosVel[j]==1) return true;  // Simply return true if we were already in vel mode.
+    if (vModePosVel[j]==VOCAB_VELOCITY_MODE) return true;  // Simply return true if we were already in vel mode.
     // Do anything additional before setting flag to vel...
-    vModePosVel[j] = 1;  // Set flag to vel.
+    vModePosVel[j] = VOCAB_VELOCITY_MODE;  // Set flag to vel.
     return true;
 }
 

--- a/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
@@ -6,13 +6,14 @@
 
 bool RaveBot::setPositionMode(int j) {
     printf("[RaveBot] setPositionMode(%d)\n", j);
-    if (modePosVel==0) return true;  // Simply return true if we were already in pos mode.
+    if ((unsigned int)j>numMotors) return false;
+    if (vModePosVel[j]==0) return true;  // Simply return true if we were already in pos mode.
     // Do anything additional before setting flag to pos...
     if(!stop()) {
         fprintf(stderr,"[RaveBot] warning: setPositionMode() return false; failed to stop\n");
         return false;
     }
-    modePosVel = 0;
+    vModePosVel[j] = 0;  // Set flag to pos.
     return true;
 }
 
@@ -20,10 +21,11 @@ bool RaveBot::setPositionMode(int j) {
 
 bool RaveBot::setVelocityMode(int j) {
     printf("[RaveBot] setVelocityMode(%d)\n", j);
-    if (modePosVel==1) return true;  // Simply return true if we were already in vel mode.
+    if ((unsigned int)j>numMotors) return false;
+    if (vModePosVel[j]==1) return true;  // Simply return true if we were already in vel mode.
     // Do anything additional before setting flag to vel...
-    modePosVel = 1;  // Set flag to vel.
-    return false;
+    vModePosVel[j] = 1;  // Set flag to vel.
+    return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IControlModeImpl.cpp
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#include "RaveBot.h"
+
+// ------------------- IControlMode Related ------------------------------------
+
+bool RaveBot::setPositionMode(int j) {
+    printf("[RaveBot] setPositionMode(%d)\n", j);
+    if (modePosVel==0) return true;  // Simply return true if we were already in pos mode.
+    // Do anything additional before setting flag to pos...
+    if(!stop()) {
+        fprintf(stderr,"[RaveBot] warning: setPositionMode() return false; failed to stop\n");
+        return false;
+    }
+    modePosVel = 0;
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::setVelocityMode(int j) {
+    printf("[RaveBot] setVelocityMode(%d)\n", j);
+    if (modePosVel==1) return true;  // Simply return true if we were already in vel mode.
+    // Do anything additional before setting flag to vel...
+    modePosVel = 1;  // Set flag to vel.
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::setTorqueMode(int j) {
+    return false; // unimplemented
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::setImpedancePositionMode(int j) {
+    return false; // unimplemented
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::setImpedanceVelocityMode(int j) {
+    return false; // unimplemented
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::setOpenLoopMode(int j) {
+    return false; // unimplemented
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::getControlMode(int j, int *mode) {
+    return false; // unimplemented
+}
+
+// -----------------------------------------------------------------------------
+
+bool RaveBot::getControlModes(int *modes) {
+    return false; // unimplemented
+}
+
+// -----------------------------------------------------------------------------
+

--- a/src/libraries/RlPlugins/ravebot/IDeviceImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IDeviceImpl.cpp
@@ -22,7 +22,7 @@ bool RaveBot::open(Searchable& config) {
     double genRefSpeed = DEFAULT_GEN_REF_SPEED;
     double genEncRawExposed = DEFAULT_GEN_ENC_RAW_EXPOSED;
     double genVelRawExposed = DEFAULT_GEN_VEL_RAW_EXPOSED;
-    modePosVel = DEFAULT_MODE_POS_VEL;
+    int modePosVel = DEFAULT_MODE_POS_VEL;
     ConstString physics = DEFAULT_PHYSICS;
     viewer = DEFAULT_VIEWER;
 
@@ -73,6 +73,8 @@ bool RaveBot::open(Searchable& config) {
         genRefSpeed,genEncRawExposed, genVelRawExposed);
     printf("RaveBot using jmcMs: %f, jmcMsAcc: %f, modePosVel: %d, physics: %s, viewer: %d.\n",
         jmcMs,jmcMsAcc,modePosVel,physics.c_str(),viewer);
+
+    vModePosVel.assign(numMotors, modePosVel);
 
     Bottle* initPoss;
     if (config.check("initPoss")) {

--- a/src/libraries/RlPlugins/ravebot/IDeviceImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IDeviceImpl.cpp
@@ -43,7 +43,9 @@ bool RaveBot::open(Searchable& config) {
         printf("\t--genEncRawExposed (encoder [raw / exposed] ratio, default: \"%f\")\n",genEncRawExposed);
         printf("\t--genVelRawExposed (velocity [raw / exposed] ratio, default: \"%f\")\n",genVelRawExposed);
         printf("\t--jmcMs [ms] (rate of Joint Motion Controller thread, default: \"%f\")\n",jmcMs);
-        printf("\t--modePosVel (default: \"%d\")\n",modePosVel);
+        printf("\t--modePosVel [%s | %s] (default: \"%s\")\n",
+            Vocab::decode(VOCAB_POSITION_MODE).c_str(),Vocab::decode(VOCAB_VELOCITY_MODE).c_str(),
+            Vocab::decode(modePosVel).c_str());
         printf("\t--physics [type] (type of physics, default: \"%s\")\n",physics.c_str());
         printf("\t--viewer [type] (set to 0 for none, default: \"%d\")\n",viewer);
     }
@@ -64,15 +66,15 @@ bool RaveBot::open(Searchable& config) {
     if (config.check("genVelRawExposed")) genVelRawExposed = config.find("genVelRawExposed").asDouble();    
     if (config.check("jmcMs")) jmcMs = config.find("jmcMs").asDouble();
     if (config.check("jmcMsAcc")) jmcMsAcc = config.find("jmcMsAcc").asDouble();
-    if (config.check("modePosVel")) modePosVel = config.find("modePosVel").asInt();
+    if (config.check("modePosVel")) modePosVel = config.find("modePosVel").asVocab();
     if (config.check("physics")) physics = config.find("physics").asString();
     if (config.check("viewer")) viewer = config.find("viewer").asInt();
     printf("RaveBot using genInitPos: %f, genJointTol: %f, genMaxLimit: %f, genMinLimit: %f.\n",
         genInitPos, genJointTol,genMaxLimit,genMinLimit);
     printf("RaveBot using genRefSpeed: %f, genEncRawExposed: %f, genVelRawExposed: %f.\n",
         genRefSpeed,genEncRawExposed, genVelRawExposed);
-    printf("RaveBot using jmcMs: %f, jmcMsAcc: %f, modePosVel: %d, physics: %s, viewer: %d.\n",
-        jmcMs,jmcMsAcc,modePosVel,physics.c_str(),viewer);
+    printf("RaveBot using jmcMs: %f, jmcMsAcc: %f, modePosVel: %s, physics: %s, viewer: %d.\n",
+        jmcMs,jmcMsAcc,Vocab::decode(modePosVel).c_str(),physics.c_str(),viewer);
 
     vModePosVel.assign(numMotors, modePosVel);
 

--- a/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
@@ -14,8 +14,8 @@ bool RaveBot::getAxes(int *ax) {
 
 bool RaveBot::positionMove(int j, double ref) {  // encExposed = ref;
     if ((unsigned int)j>numMotors) return false;
-    if(modePosVel!=0) {  // Check if we are in position mode.
-        fprintf(stderr,"[RaveBot] warning: will not positionMove as not in positionMode\n");
+    if(vModePosVel[j]!=0) {  // Check if we are in position mode.
+        fprintf(stderr,"[RaveBot] warning: will not positionMove as joint %d not in positionMode\n",j+1);
         return false;
     }
     printf("[RaveBot] positionMove(%d,%f) f[begin]\n",j,ref);
@@ -40,9 +40,11 @@ bool RaveBot::positionMove(int j, double ref) {  // encExposed = ref;
 // -----------------------------------------------------------------------------
 
 bool RaveBot::positionMove(const double *refs) {  // encExposed = refs;
-    if(modePosVel!=0) {  // Check if we are in position mode.
-        fprintf(stderr,"[RaveBot] error: Will not positionMove as not in positionMode\n");
-        return false;
+    for(unsigned int motor=0;motor<numMotors;motor++) {
+        if(vModePosVel[motor]!=0) {  // Check if we are in position mode.
+            fprintf(stderr,"[RaveBot] error: Will not positionMove as joint %d not in positionMode\n",motor+1);
+            return false;
+        }
     }
     printf("[RaveBot] positionMove() f[begin]\n");
     // Find out the maximum time to move
@@ -76,8 +78,8 @@ bool RaveBot::positionMove(const double *refs) {  // encExposed = refs;
 
 bool RaveBot::relativeMove(int j, double delta) {
     if ((unsigned int)j>numMotors) return false;
-    if(modePosVel!=0) {  // Check if we are in position mode.
-        printf("[fail] RaveBot will not relativeMove as not in positionMode\n");
+    if(vModePosVel[j]!=0) {  // Check if we are in position mode.
+        printf("[fail] RaveBot will not relativeMove as joint %d not in positionMode\n",j+1);
         return false;
     }
     printf("[RaveBot] relativeMove(%d,%f) f[begin]\n",j,delta);
@@ -102,9 +104,11 @@ bool RaveBot::relativeMove(int j, double delta) {
 // -----------------------------------------------------------------------------
 
 bool RaveBot::relativeMove(const double *deltas) {  // encExposed = deltas + encExposed
-    if(modePosVel!=0) {  // Check if we are in position mode.
-        fprintf(stderr,"[RaveBot] warning: will not relativeMove as not in positionMode\n");
-        return false;
+    for(unsigned int motor=0;motor<numMotors;motor++) {
+        if(vModePosVel[motor]!=0) {  // Check if we are in position mode.
+            fprintf(stderr,"[RaveBot] warning: will not relativeMove as joint %d not in positionMode\n",motor+1);
+            return false;
+        }
     }
     printf("[RaveBot] relativeMove() f[begin]\n");
     // Find out the maximum angle to move

--- a/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
@@ -12,20 +12,6 @@ bool RaveBot::getAxes(int *ax) {
 
 // -----------------------------------------------------------------------------
 
-bool RaveBot::setPositionMode() {
-    printf("[RaveBot] setPositionMode()\n");
-    if (modePosVel==0) return true;  // Simply return true if we were already in pos mode.
-    // Do anything additional before setting flag to pos...
-    if(!stop()) {
-        fprintf(stderr,"[RaveBot] warning: setPositionMode() return false; failed to stop\n");
-        return false;
-    }
-    modePosVel = 0;
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-
 bool RaveBot::positionMove(int j, double ref) {  // encExposed = ref;
     if ((unsigned int)j>numMotors) return false;
     if(modePosVel!=0) {  // Check if we are in position mode.

--- a/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
@@ -14,7 +14,7 @@ bool RaveBot::getAxes(int *ax) {
 
 bool RaveBot::positionMove(int j, double ref) {  // encExposed = ref;
     if ((unsigned int)j>numMotors) return false;
-    if(vModePosVel[j]!=0) {  // Check if we are in position mode.
+    if(vModePosVel[j]!=VOCAB_POSITION_MODE) {  // Check if we are in position mode.
         fprintf(stderr,"[RaveBot] warning: will not positionMove as joint %d not in positionMode\n",j+1);
         return false;
     }
@@ -41,7 +41,7 @@ bool RaveBot::positionMove(int j, double ref) {  // encExposed = ref;
 
 bool RaveBot::positionMove(const double *refs) {  // encExposed = refs;
     for(unsigned int motor=0;motor<numMotors;motor++) {
-        if(vModePosVel[motor]!=0) {  // Check if we are in position mode.
+        if(vModePosVel[motor]!=VOCAB_POSITION_MODE) {  // Check if we are in position mode.
             fprintf(stderr,"[RaveBot] error: Will not positionMove as joint %d not in positionMode\n",motor+1);
             return false;
         }
@@ -78,7 +78,7 @@ bool RaveBot::positionMove(const double *refs) {  // encExposed = refs;
 
 bool RaveBot::relativeMove(int j, double delta) {
     if ((unsigned int)j>numMotors) return false;
-    if(vModePosVel[j]!=0) {  // Check if we are in position mode.
+    if(vModePosVel[j]!=VOCAB_POSITION_MODE) {  // Check if we are in position mode.
         printf("[fail] RaveBot will not relativeMove as joint %d not in positionMode\n",j+1);
         return false;
     }
@@ -105,7 +105,7 @@ bool RaveBot::relativeMove(int j, double delta) {
 
 bool RaveBot::relativeMove(const double *deltas) {  // encExposed = deltas + encExposed
     for(unsigned int motor=0;motor<numMotors;motor++) {
-        if(vModePosVel[motor]!=0) {  // Check if we are in position mode.
+        if(vModePosVel[motor]!=VOCAB_POSITION_MODE) {  // Check if we are in position mode.
             fprintf(stderr,"[RaveBot] warning: will not relativeMove as joint %d not in positionMode\n",motor+1);
             return false;
         }

--- a/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
@@ -6,7 +6,7 @@
 
 bool RaveBot::velocityMove(int j, double sp) {  // velExposed = sp;
     if ((unsigned int)j>numMotors) return false;
-    if(vModePosVel[j]!=1) {  // Check if we are in velocity mode.
+    if(vModePosVel[j]!=VOCAB_VELOCITY_MODE) {  // Check if we are in velocity mode.
         fprintf(stderr,"[RaveBot] fail: RaveBot will not velocityMove as joint %d not in velocityMode\n",j+1);
         return false;
     }

--- a/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
@@ -4,16 +4,6 @@
 
 // ------------------ IVelocity Related ----------------------------------------
 
-bool RaveBot::setVelocityMode() {
-    printf("[RaveBot] setVelocityMode()\n");
-    if (modePosVel==1) return true;  // Simply return true if we were already in vel mode.
-    // Do anything additional before setting flag to vel...
-    modePosVel = 1;  // Set flag to vel.
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-
 bool RaveBot::velocityMove(int j, double sp) {  // velExposed = sp;
     if ((unsigned int)j>numMotors) return false;
     if(modePosVel!=1) {  // Check if we are in velocity mode.

--- a/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
@@ -6,8 +6,8 @@
 
 bool RaveBot::velocityMove(int j, double sp) {  // velExposed = sp;
     if ((unsigned int)j>numMotors) return false;
-    if(modePosVel!=1) {  // Check if we are in velocity mode.
-        fprintf(stderr,"[RaveBot] fail: RaveBot will not velocityMove as not in velocityMode\n");
+    if(vModePosVel[j]!=1) {  // Check if we are in velocity mode.
+        fprintf(stderr,"[RaveBot] fail: RaveBot will not velocityMove as joint %d not in velocityMode\n",j+1);
         return false;
     }
     velRaw[j] = (sp * velRawExposed[j]);

--- a/src/libraries/RlPlugins/ravebot/RaveBot.h
+++ b/src/libraries/RlPlugins/ravebot/RaveBot.h
@@ -35,7 +35,7 @@
 #define DEFAULT_GEN_VEL_RAW_EXPOSED 0.0174532925199433  // Ratio, 0.0174532925199433 is pi/180 (raw/exp)<->(rad/deg)
 #define DEFAULT_JMC_MS 20  // [ms]
 #define DEFAULT_JMC_MS_ACC 1  // multiplier
-#define DEFAULT_MODE_POS_VEL 0  // 0=Position, 1=Velocity.
+#define DEFAULT_MODE_POS_VEL VOCAB_POSITION_MODE
 #define DEFAULT_PHYSICS "none"
 #define DEFAULT_VIEWER 1
 

--- a/src/libraries/RlPlugins/ravebot/RaveBot.h
+++ b/src/libraries/RlPlugins/ravebot/RaveBot.h
@@ -69,7 +69,7 @@ using namespace OpenRAVE;
  * and <a class="el" href="group__cartesianServer.html">cartesianServer</a>.
  *
  */
-class RaveBot : public DeviceDriver, public RateThread, public IPositionControl, public IVelocityControl, public IEncodersTimed, public IControlLimits {
+class RaveBot : public DeviceDriver, public RateThread, public IPositionControl, public IVelocityControl, public IEncodersTimed, public IControlLimits, public IControlMode {
  public:
 
   // Set the Thread Rate in the class constructor
@@ -84,14 +84,6 @@ class RaveBot : public DeviceDriver, public RateThread, public IPositionControl,
      * @return true/false.
      */
     virtual bool getAxes(int *ax);
-
-    /** Set position mode. This command
-     * is required by control boards implementing different
-     * control methods (e.g. velocity/torque), in some cases
-     * it can be left empty.
-     * return true/false on success/failure
-     */
-    virtual bool setPositionMode();
 
     /** Set new reference point for a single axis.
      * @param j joint number
@@ -295,15 +287,6 @@ class RaveBot : public DeviceDriver, public RateThread, public IPositionControl,
 //  --------- IVelocityControl Declarations. Implementation in IVelocityImpl.cpp ---------
 
     /**
-     * Set velocity mode. This command
-     * is required by control boards implementing different
-     * control methods (e.g. velocity/torque), in some cases
-     * it can be left empty.
-     * @return true/false on success failure
-     */
-    virtual bool setVelocityMode();
-
-    /**
      * Start motion at a given speed, single joint.
      * @param j joint number
      * @param sp speed value
@@ -337,6 +320,65 @@ class RaveBot : public DeviceDriver, public RateThread, public IPositionControl,
      * @return true if everything goes fine, false otherwise.
      */
     virtual bool getLimits(int axis, double *min, double *max);
+
+// -------- IControlMode declarations. Implementation in IControlModeImpl.cpp --------
+
+    /**
+     * Set position mode, single axis.
+     * @param j joint number
+     * @return: true/false success failure.
+     */
+    virtual bool setPositionMode(int j);
+
+    /**
+     * Set velocity mode, single axis.
+     * @param j joint number
+     * @return: true/false success failure.
+     */
+    virtual bool setVelocityMode(int j);
+
+    /**
+     * Set torque mode, single axis.
+     * @param j joint number
+     * @return: true/false success failure.
+     */
+    virtual bool setTorqueMode(int j);
+
+    /**
+     * Set impedance position mode, single axis.
+     * @param j joint number
+     * @return: true/false success failure.
+     */
+    virtual bool setImpedancePositionMode(int j);
+
+    /**
+     * Set impedance velocity mode, single axis.
+     * @param j joint number
+     * @return: true/false success failure.
+     */
+    virtual bool setImpedanceVelocityMode(int j);
+
+    /**
+     * Set open loop mode, single axis.
+     * @param j joint number
+     * @return: true/false success failure.
+     */
+    virtual bool setOpenLoopMode(int j);
+
+    /**
+     * Get the current control mode.
+     * @param j joint number
+     * @param mode a vocab of the current control mode for joint j.
+     * @return: true/false success failure.
+     */
+    virtual bool getControlMode(int j, int *mode);
+
+    /**
+     * Get the current control mode (multiple joints).
+     * @param modes a vector containing vocabs for the current control modes of the joints.
+     * @return: true/false success failure.
+     */
+    virtual bool getControlModes(int *modes);
 
 // -------- DeviceDriver declarations. Implementation in IDeviceImpl.cpp --------
 

--- a/src/libraries/RlPlugins/ravebot/RaveBot.h
+++ b/src/libraries/RlPlugins/ravebot/RaveBot.h
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 #include "WorldRpcResponder.h"
 #include "MobileRpcResponder.h"
@@ -434,7 +435,7 @@ class RaveBot : public DeviceDriver, public RateThread, public IPositionControl,
     // General Joint Motion Controller parameters //
     unsigned int numMotors;
     //
-    int modePosVel;
+    std::vector<int> vModePosVel;
     double lastTime;
     Semaphore encRawMutex;  // SharedArea
     std::vector<double> encRaw;


### PR DESCRIPTION
Deprecated yarp::dev::IPositionControl::setPositionMode() and
yarp::dev::IVelocityControl::setVelocityMode() were no longer supported
by their corresponding adapter methods in ControlBoardWrapper.

TODOs:
- get rid of remaining calls to deprecated setXXMode functions
- implement "new" IControlMode2 interface in RaveBot

References:
- https://github.com/robotology/yarp/pull/708
- http://www.yarp.it/classyarp_1_1dev_1_1IControlMode.html
- http://www.yarp.it/classyarp_1_1dev_1_1IControlMode2.html
- http://www.yarp.it/classyarp_1_1dev_1_1ControlBoardWrapper.html
- http://www.yarp.it/ControlBoardWrapper_8cpp_source.html#l01405
- http://www.yarp.it/ControlBoardWrapper_8cpp_source.html#l02593

This patch targets issue #12.
