### PR TITLE
Restore deleted RaveBot methods for compatibility with YARP <2.3.65

### DIFF
--- a/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IPositionImpl.cpp
@@ -4,6 +4,10 @@
 
 // ------------------- IPositionControl Related --------------------------------
 
+bool RaveBot::setPositionMode() {
+    return false;
+}
+
 bool RaveBot::getAxes(int *ax) {
     *ax = numMotors;
     printf("[RaveBot] getAxes reporting %d axes are present\n", *ax);

--- a/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
+++ b/src/libraries/RlPlugins/ravebot/IVelocityImpl.cpp
@@ -4,6 +4,10 @@
 
 // ------------------ IVelocity Related ----------------------------------------
 
+bool RaveBot::setVelocityMode() {
+    return false;
+}
+
 bool RaveBot::velocityMove(int j, double sp) {  // velExposed = sp;
     if ((unsigned int)j>numMotors) return false;
     if(vModePosVel[j]!=VOCAB_VELOCITY_MODE) {  // Check if we are in velocity mode.

--- a/src/libraries/RlPlugins/ravebot/RaveBot.h
+++ b/src/libraries/RlPlugins/ravebot/RaveBot.h
@@ -86,6 +86,16 @@ class RaveBot : public DeviceDriver, public RateThread, public IPositionControl,
      */
     virtual bool getAxes(int *ax);
 
+    /** Set position mode. This command
+     * is required by control boards implementing different
+     * control methods (e.g. velocity/torque), in some cases
+     * it can be left empty.
+     * return true/false on success/failure
+     * @note kept for backwards compatibility with YARP <2.3.65,
+     * use \ref setPositionMode(int) instead
+     */
+    virtual bool setPositionMode();
+
     /** Set new reference point for a single axis.
      * @param j joint number
      * @param ref specifies the new ref point
@@ -286,6 +296,17 @@ class RaveBot : public DeviceDriver, public RateThread, public IPositionControl,
 
 
 //  --------- IVelocityControl Declarations. Implementation in IVelocityImpl.cpp ---------
+
+    /**
+     * Set velocity mode. This command
+     * is required by control boards implementing different
+     * control methods (e.g. velocity/torque), in some cases
+     * it can be left empty.
+     * @return true/false on success failure
+     * @note kept for backwards compatibility with YARP <2.3.65,
+     * use \ref setVelocityMode(int) instead
+     */
+    virtual bool setVelocityMode();
 
     /**
      * Start motion at a given speed, single joint.


### PR DESCRIPTION
Partially reverts 067d271.
